### PR TITLE
Add support for Pixel 3 devices in release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -83,4 +83,4 @@ fi
 
 mv $DEVICE-$VERSION-factory.tar $DEVICE-factory-$BUILD_NUMBER.tar
 rm -f $DEVICE-factory-$BUILD_NUMBER.tar.xz
-xz -v --lzma2=dict=512MiB,lc=3,lp=0,pb=2,mode=normal,nice=64,mf=bt4,depth=0 $DEVICE-factory-$BUILD_NUMBER.tar
+pxz -v $DEVICE-factory-$BUILD_NUMBER.tar

--- a/release.sh
+++ b/release.sh
@@ -10,48 +10,71 @@ user_error() {
 
 KEY_DIR=keys/$1
 OUT=out/release-$1-$BUILD_NUMBER
+PREFIX=aosp_
 
 source device/common/clear-factory-images-variables.sh
+
+DEVICE=$1
+case "$DEVICE" in
+  hikey*)
+    VERITY_MODE=none
+    PREFIX=
+    ;;
+  bullhead)
+    VENDOR=lge
+    VERITY_MODE=legacy
+    ;;
+  angler)
+    VENDOR=huawei
+    VERITY_MODE=legacy
+    ;;
+  marlin|sailfish)
+    VENDOR=google_devices
+    VERITY_MODE=legacy
+    ;;
+  taimen|walleye)
+    VENDOR=google_devices
+    VERITY_MODE=avb1
+    ;;
+  crosshatch|blueline|*)
+    VENDOR=google_devices
+    VERITY_MODE=avb2
+esac
 
 get_radio_image() {
   grep -Po "require version-$1=\K.+" vendor/$2/vendor-board-info.txt | tr '[:upper:]' '[:lower:]'
 }
 
-if [[ $1 == bullhead ]]; then
-  BOOTLOADER=$(get_radio_image bootloader lge/$1)
-  RADIO=$(get_radio_image baseband lge/$1)
-  PREFIX=aosp_
-elif [[ $1 == angler ]]; then
-  BOOTLOADER=$(get_radio_image bootloader huawei/$1)
-  RADIO=$(get_radio_image baseband huawei/$1)
-  PREFIX=aosp_
-elif [[ $1 == marlin || $1 == sailfish || $1 == taimen || $1 == walleye ]]; then
-  BOOTLOADER=$(get_radio_image bootloader google_devices/$1)
-  RADIO=$(get_radio_image baseband google_devices/$1)
-  PREFIX=aosp_
-elif [[ $1 == hikey || $1 == hikey960 ]]; then
-  :
-else
-  user_error
+if [ -n "$VENDOR" ]; then
+  BOOTLOADER=$(get_radio_image bootloader $VENDOR/$1)
+  RADIO=$(get_radio_image baseband $VENDOR/$1)
 fi
 
 BUILD=$BUILD_NUMBER
 VERSION=$(grep -Po "export BUILD_ID=\K.+" build/core/build_id.mk | tr '[:upper:]' '[:lower:]')
-DEVICE=$1
-PRODUCT=$1
 
 mkdir -p $OUT || exit 1
 
 TARGET_FILES=$DEVICE-target_files-$BUILD.zip
 
-if [[ $DEVICE != hikey* ]]; then
-  if [[ $DEVICE != taimen && $DEVICE != walleye ]]; then
+case "$VERITY_MODE" in
+  legacy)
     VERITY_SWITCHES=(--replace_verity_public_key "$KEY_DIR/verity_key.pub" --replace_verity_private_key "$KEY_DIR/verity"
                      --replace_verity_keyid "$KEY_DIR/verity.x509.pem")
-  else
+    ;;
+  avb1)
+    # Use avb.pem to sign vbmeta.img, which contains salts + hashes for
+    # all partitions.
     VERITY_SWITCHES=(--avb_vbmeta_key "$KEY_DIR/avb.pem" --avb_vbmeta_algorithm SHA256_RSA2048)
-  fi
-fi
+    ;;
+  avb2)
+    # By default, Android sets BOARD_AVB_SYSTEM_KEY_PATH to
+    # external/avb/test/data/testkey_rsa2048.pem, which means system.img
+    # uses a chained descriptor signed with an insecure test key.  Replace
+    # the test key with our own avb.pem.
+    VERITY_SWITCHES=(--avb_vbmeta_key "$KEY_DIR/avb.pem" --avb_vbmeta_algorithm SHA256_RSA2048 --avb_system_key "$KEY_DIR/avb.pem" --avb_system_algorithm SHA256_RSA2048)
+    ;;
+esac
 
 if [[ $DEVICE == bullhead ]]; then
   EXTRA_OTA=(-b device/lge/bullhead/update-binary)
@@ -71,6 +94,9 @@ build/tools/releasetools/img_from_target_files $OUT/$TARGET_FILES \
   $OUT/$DEVICE-img-$BUILD.zip || exit 1
 
 cd $OUT || exit 1
+
+# used by generate-factory-images-common.sh
+PRODUCT=$DEVICE
 
 if [[ $DEVICE == hikey* ]]; then
   source ../../device/linaro/hikey/factory-images/generate-factory-images-$DEVICE.sh


### PR DESCRIPTION
The standard builds for AVB 2.0 devices will try to sign the system.img vbmeta block with an insecure test key, causing a verity error on boot (eio / red screen).  Override it to use avb.pem instead.

This patch also consolidates some of the per-device settings to one big case block.

(Not sure whether this repo is intended to be used going forward?  I just looked at refs/heads/9.0 on rattlesnakeos-stack and that has merged parts of release.sh into build.sh.  And my pxz patch is probably redundant too...)